### PR TITLE
added 'noexcept nogil' to grammar patterns

### DIFF
--- a/grammars/cython.syntax.yaml
+++ b/grammars/cython.syntax.yaml
@@ -54,7 +54,7 @@ repository:
           (?x)
             \b(?:
               (
-                nogil | gil | include | extern | extern from | noexcept | namespace
+                nogil | gil | include | extern | extern from | noexcept | namespace | noexcept nogil
               ) | (
                 as | cimport
               ) | (


### PR DESCRIPTION
Added in "noexcept nogil" as an acceptable pattern to grammar check. Addressing issue #20.

_This is untested!_ I could not get the extension to compile locally (using windows) so I was not able to test this; thus the draft PR. If someone else can test it or I can try to build it on another OS some time.